### PR TITLE
Add 'catch' to purchase bonds&stocks&repo

### DIFF
--- a/examples/joinquant/convertible_bonds_purchase.py
+++ b/examples/joinquant/convertible_bonds_purchase.py
@@ -17,4 +17,8 @@ def process_initialize(context):
 
 
 def purchase_convertible_bonds(context):
-    g.__manager.purchase_convertible_bonds()
+    try:
+        g.__manager.purchase_convertible_bonds()
+    except:
+        import traceback
+        traceback.print_exc()

--- a/examples/joinquant/new_stocks_purchase.py
+++ b/examples/joinquant/new_stocks_purchase.py
@@ -17,4 +17,8 @@ def process_initialize(context):
 
 
 def purchase_new_stocks(context):
-    g.__manager.purchase_new_stocks()
+    try:
+        g.__manager.purchase_new_stocks()
+    except:
+        import traceback
+        traceback.print_exc()

--- a/examples/joinquant/repo.py
+++ b/examples/joinquant/repo.py
@@ -16,4 +16,8 @@ def process_initialize(context):
 
 
 def repo(context):
-    g.__manager.repo()
+    try:
+        g.__manager.repo()
+    except:
+        import traceback
+        traceback.print_exc()

--- a/examples/ricequant/convertible_bonds_purchase.py
+++ b/examples/ricequant/convertible_bonds_purchase.py
@@ -18,4 +18,9 @@ def before_trading(context):
 
 
 def purchase_convertible_bonds(context, bar_dict):
-    context.__manager.purchase_convertible_bonds()
+    try:
+        context.__manager.purchase_convertible_bonds()
+    except:
+        import sys
+        s = sys.exc_info()
+        logger.error("Error '%s' happened on line %d" % (s[1],s[2].tb_lineno))

--- a/examples/ricequant/new_stocks_purchase.py
+++ b/examples/ricequant/new_stocks_purchase.py
@@ -18,4 +18,9 @@ def before_trading(context):
 
 
 def purchase_new_stocks(context, bar_dict):
-    context.__manager.purchase_new_stocks()
+    try:
+        context.__manager.purchase_new_stocks()
+    except:
+        import sys
+        s = sys.exc_info()
+        logger.error("Error '%s' happened on line %d" % (s[1],s[2].tb_lineno))

--- a/examples/ricequant/repo.py
+++ b/examples/ricequant/repo.py
@@ -16,4 +16,9 @@ def process_initialize(context):
 
 
 def repo(context):
-    context.__manager.repo()
+    try:
+        context.__manager.repo()
+    except:
+        import sys
+        s = sys.exc_info()
+        logger.error("Error '%s' happened on line %d" % (s[1],s[2].tb_lineno))


### PR DESCRIPTION
import traceback
traceback.print_exc()
的方法回溯详细些，但是米筐不支持
故米筐logger.error("Error '%s' happened on line %d" % (s[1],s[2].tb_lineno))